### PR TITLE
[Hw-Wallet-Js]: Stop autostarting main.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "hardware-wallet-js",
   "version": "1.0.0",
   "description": "[![Build Status](https://travis-ci.com/skycoin/hardware-wallet-js.svg?branch=master)](https://travis-ci.com/skycoin/hardware-wallet-js)",
-  "main": "main.js",
   "scripts": {
     "start": "node main.js",
     "lint": "./node_modules/.bin/eslint ./*.js",


### PR DESCRIPTION
When this library is imported with npm, `main.js` starts running automatically when the application that uses the library is started. This pr prevents that from happening.