### PR TITLE
[Hardware-wallet]: Close deviceHandle in devGetFeatures

### DIFF
--- a/device-wallet.js
+++ b/device-wallet.js
@@ -1053,6 +1053,7 @@ const devGetFeatures = function() {
         const dataBytes = createGetFeaturesRequest();
         const deviceHandle = new DeviceHandler(deviceType);
         deviceHandle.read((kind, data) => {
+            deviceHandle.close();
             resolve(decodeFeaturesRequest(kind, data));
         });
         deviceHandle.write(dataBytes);


### PR DESCRIPTION
On the Mac it is not possible to call `var hw = new HID.HID(foundHw.path);` again if the previous instance is not closed first, so this change is necessary for the library to work on that OS.