### PR TITLE
Fix the devWipeDevice function

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -533,7 +533,7 @@ Wipes the hardware wallet, so that it is possible to configure it again as a new
 *Return value:*
 
 A promise that receives a text string that depends on the result of the operation:
-- If the user cancels the operation: `Wipe Device operation failed or refused`.
+- If the user cancels the operation (promise rejected): `Error: Wipe Device operation failed or refused`.
 - If the operation ends correctly: `Wipe Device operation completed`.
 
 *Notes:*

--- a/device-wallet.js
+++ b/device-wallet.js
@@ -976,7 +976,7 @@ const devCheckMessageSignature = function(address, message, signature, passphras
 };
 
 const devWipeDevice = function() {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
             const dataBytes = createWipeDeviceRequest();
             const deviceHandle = new DeviceHandler(deviceType);
             const devReadCallback = function(kind, d) {
@@ -985,7 +985,7 @@ const devWipeDevice = function() {
                     if (datakind == messages.MessageType.MessageType_Success) {
                         resolve("Wipe Device operation completed");
                     } else {
-                        reject("Wipe Device operation failed or refused");
+                        reject(new Error("Wipe Device operation failed or refused"));
                     }
                 });
             };


### PR DESCRIPTION
Changes:
- The `devWipeDevice` function is throwing an unexpected error when the user cancels the operation in the hardware wallet. This PR solves the problem.

Does this change need to mentioned in CHANGELOG.md?
No

Requires testing
No

Comments about testing , should you have some
If there is an automatic test depending on the erroneous behavior, it should be updated.