### PR TITLE
replace secure-random by randombytes fixes #65

### DIFF
--- a/device-wallet.js
+++ b/device-wallet.js
@@ -4,7 +4,7 @@ const bufReceiver = require('./buffer-receiver');
 const dgram = require('dgram');
 const scanf = require('scanf');
 const os = require('os');
-const secureRandom = require('secure-random');
+const randomBytes = require('randombytes');
 
 let deviceType = 0;
 let autoPressButtons = false;
@@ -348,7 +348,7 @@ const createSetMnemonicRequest = function(mnemonic) {
 };
 
 const createEntropyAckRequest = function(bufferSize) {
-    const entropy = secureRandom.randomUint8Array(bufferSize);
+    const entropy = randomBytes(bufferSize);
     const msgStructure = {
         entropy
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2972,14 +2972,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2999,8 +2997,7 @@
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -5035,6 +5032,14 @@
         }
       }
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5586,11 +5591,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/scanf/-/scanf-1.0.2.tgz",
       "integrity": "sha512-3WTLRdIAypK0117Fqep8rXlUesYyz8kcMsC4ATSFO6tqGmxmzohFizIKOIrgKCs1b7RYR9QI6XOFrvH5ZGP/iA=="
-    },
-    "secure-random": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/secure-random/-/secure-random-1.1.1.tgz",
-      "integrity": "sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo="
     },
     "semver": {
       "version": "5.5.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "mocha": "^6.0.2",
     "node-hid": "^0.7.3",
     "protobufjs": "^6.8.8",
+    "randombytes": "^2.1.0",
     "scanf": "^1.0.2",
-    "secure-random": "^1.1.1",
     "serial-mocha": "0.0.4",
     "usb": "^1.3.3"
   },


### PR DESCRIPTION
Fixes #65 

Changes:
- `randombytes` superseded `secure-random`

Does this change need to mentioned in CHANGELOG.md?
no

Requires testing
no
