### PR TITLE
Some updates for the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add a new npm package "secure-random": "^1.1.1"
+- Add a new npm package "randombytes": "^2.1.0"
 - Support device label in message to apply settings
 - Use `protobuf` file definitions from a [`git submodule`](http://github.com/skycoin/hardware-wallet-protob.git).
 - In `devGenerateMnemonic` message (function) it is possible to specify the `word_count` for the seed.

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -287,7 +287,8 @@ asking for it very frequently).
 *Return value:*
 
 A promise that receives a text string that depends on the result of the operation:
-- If the hardware wallet alreadys has a mnemonic: `Generate Mnemonic operation failed or refused`.
+- If the hardware wallet already has a mnemonic or `wordCount` has an invalid value
+(promise rejected): `Error: Generate Mnemonic operation failed or refused`.
 - If the operation ends correctly: `Generate Mnemonic operation completed`.
 
 *Notes:*
@@ -354,8 +355,8 @@ asking for it very frequently).
 *Return value:*
 
 A promise that receives a text string that depends on the result of the operation:
-- If the wallet already has a mnemonic or the user cancels the operation (promise rejected):
-`Error: Expected WordAck after Button confirmation`.
+- If the wallet already has a mnemonic, the user cancels the operation or `wordCount` has an invalid value
+(promise rejected): `Error: Expected WordAck after Button confirmation`.
 - If the hardware wallet asks for a specific word and a different word is entered (promise rejected):
 `Error: Wrong word retyped`.
 - If the user enters a word that is not part of the dictionary (promise rejected):


### PR DESCRIPTION
Changes:
- The documentation about the `devRecoveryDevice` and `devGenerateMnemonic` functions was updated to include changes made in past PRs.

- The entry in the changelog about the rng dependency was updated.

Does this change need to mentioned in CHANGELOG.md?
No

Requires testing
No

Comments about testing , should you have some
None