### PR TITLE
[ci] fixes #94 - Run eslint --fix in npm format

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "start": "node main.js",
     "lint": "./node_modules/.bin/eslint ./*.js test/*.js",
-    "format": "./node_modules/.bin/eslint ./*.js test/*.js",
+    "format": "./node_modules/.bin/eslint --fix ./*.js test/*.js",
     "make-device-detection": "./node_modules/.bin/babel ./device-detection/*.js ./device-detection/hw-transport/*.js -d device-detection-lib/",
     "make-protobuf-files": "make -C protob build-js",
     "test": "./node_modules/.bin/serial-mocha ./test/*.js"


### PR DESCRIPTION
Fixes #94

Changes:
- Run `eslint --fix` in npm format

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
no
