### PR TITLE
fixes #103 - Document firmware features

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,3 +15,9 @@ Requires testing
 yes | no
 
 Comments about testing , should you have some
+
+Related issues:
+
+PR skycoin/hardware-wallet# for issue skycoin/hardware-wallet#
+PR skycoin/hardware-wallet-protob# for issue skycoin/hardware-wallet-protob#
+

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -53,6 +53,8 @@ The following actions are possible
 - Ask the device to cancel the ongoing procedure - see [devCancelRequest](#devCancelRequest)
 - Ask the device to sign a transaction using the provided information - see [devSkycoinTransactionSign](#devSkycoinTransactionSign)
 
+**Note**: The javascript library provides no support for neither `GetRawEntropy` nor `GetMixedEntropy` messages.
+
 ## General characteristics to take into account
 
 - As many of the operations performed by the hardware wallet can be slow, most of the functions of the library

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -327,12 +327,14 @@ Features {
   pinCached: false,
   passphraseCached: false,
   needsBackup: false,
-  model: '1'
+  model: '1',
+  firmwareFeatures: '1'
 }
 ```
 
 *Notes:*
 - This function can be called even when the hardware wallet does not have a seed.
+- `firmwareFeatures` is interpreted like a bit slice, bit at `0` is active if user confirmation required prior to returning internal entropy, and in bit `1` if is enabled support for sending internal entropy back to the peer.
 
 ### devRecoveryDevice
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -364,7 +364,9 @@ Features {
 
 *Notes:*
 - This function can be called even when the hardware wallet does not have a seed.
-- `firmwareFeatures` is interpreted like a bit slice, bit at `0` is active if user confirmation required prior to returning internal entropy, and in bit `1` if is enabled support for sending internal entropy back to the peer.
+- `firmwareFeatures` is interpreted as a bits slice as follows
+  * bit `0` (i.e. mask `0x1`) is active if user confirmation required prior to returning internal entropy
+  * bit `1` (i.e. mask `0x2`) if support for sending internal entropy back to the peer is enabled in firmware.
 
 ### devRecoveryDevice
 

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -368,7 +368,7 @@ Features {
 - This function can be called even when the hardware wallet does not have a seed.
 - `firmwareFeatures` is interpreted as a bits slice as follows
   * bit `0` (i.e. mask `0x1`) is active if user confirmation required prior to returning internal entropy
-  * bit `1` (i.e. mask `0x2`) if support for sending internal entropy back to the peer is enabled in firmware.
+  * bit `1` (i.e. mask `0x2`) set if support for sending internal entropy back to the peer is enabled in firmware.
 
 ### devRecoveryDevice
 


### PR DESCRIPTION
Fixes #103

Changes:
- Added documentation for Firmware features in `DOCUMENTATION.md`

Does this change need to mentioned in CHANGELOG.md?
yes | no

Requires changes in protobuff specs?
no

Requires testing
no
