### PR TITLE
Improve cancel request handler

### DIFF
--- a/device-wallet.js
+++ b/device-wallet.js
@@ -10,7 +10,7 @@ const randomBytes = require('randombytes');
 let deviceType = 0;
 let autoPressButtons = false;
 let autoPressCircular = true;
-let autoPressSequence = [ 'R' ];
+let autoPressSequence = ['R'];
 let autoPressId = 0;
 
 const setDeviceType = function(devType) {
@@ -47,9 +47,12 @@ const setAutoPressButton = function(value, def, circular) {
     autoPressSequence = [].concat(sequence);
     autoPressId = 0;
 
-    return null; /// Done
+    return null;
 
   }
+
+  return 'Not in emulator';
+
 };
 
 /*
@@ -196,10 +199,9 @@ const closeAll = function () {
 
   for (let i = handlers.length - 1; i >= 0; i -= 1) {
     try {
-      if ( handlers[i].called ) {
-        continue;
+      if ( !handlers[i].called ) {
+        handlers[i].apply(null, arguments);
       }
-      handlers[i].apply(null, arguments);
     } catch(e) {}
   }
 

--- a/device-wallet.js
+++ b/device-wallet.js
@@ -28,18 +28,18 @@ const setAutoPressButton = function(value, def, circular) {
     } else if ( Array.isArray(def) ) {
       sequence = [].concat(def);
     } else {
-      return 'Only string or Array allowed as parameter';
+      throw new TypeError('Only string or Array allowed as parameter');
     }
 
     for ( let i = 0, maxi = sequence.length; i < maxi; i += 1 ) {
       if (['R', 'L', 'B'].indexOf(sequence[i]) === -1) {
-        return `${sequence[i]} does not belong to the set { "R", "L", "B" }`;
+        throw new TypeError(`${sequence[i]} does not belong to the set { "R", "L", "B" }`);
       }
     }
 
     if ( sequence.length === 0 ) {
       autoPressButtons = false;
-      return 'Sequence provided is empty';
+      throw new ReferenceError('Sequence provided is empty');
     }
 
     autoPressButtons = Boolean(value);
@@ -47,11 +47,9 @@ const setAutoPressButton = function(value, def, circular) {
     autoPressSequence = [].concat(sequence);
     autoPressId = 0;
 
-    return null;
-
   }
 
-  return 'Not in emulator';
+  throw new Error('Not in emulator');
 
 };
 

--- a/test/cancel-request-test.js
+++ b/test/cancel-request-test.js
@@ -9,30 +9,25 @@ describe("Cancel Request test", function() {
   if (deviceWallet.getDevice() === null) {
     console.log("Skycoin hardware NOT FOUND, using emulator");
     deviceWallet.setDeviceType(deviceWallet.DeviceTypeEnum.EMULATOR);
-    deviceWallet.setAutoPressButton(true, "R", false);
+    //deviceWallet.setAutoPressButton(true, "R", false);
   } else {
     console.log("Skycoin hardware is plugged in");
     deviceWallet.setDeviceType(deviceWallet.DeviceTypeEnum.USB);
   }
 
   it("Should cancel pending requests", function(done) {
+    console.log('Autopress: ', deviceWallet.setAutoPressButton(true, "R", false));
     setTimeout(function() {
       deviceWallet.
         devCancelRequest().
         then(() => {
           // Done();
-          console.log("Cancel request sent");
+          console.log("Cancel request Done");
         }).
         catch((err) => {
           console.log("Cancel request error: ", err);
         });
     }, 2000);
-
-    setTimeout(function() {
-      deviceWallet.devCancelRequest().then(() => {
-        // Done();
-      });
-    }, 4000);
 
     setup().
       then(deviceWallet.devChangePin).
@@ -44,8 +39,22 @@ describe("Cancel Request test", function() {
       });
   });
 
-  it("Should change and remove PIN if not canceled", function() {
-    return setup().
+  it("Should change and remove PIN if not canceled", function(done) {
+    console.log('Autopress: ', deviceWallet.setAutoPressButton(true, "R"));
+
+    setTimeout(function() {
+      deviceWallet.
+        devCancelRequest().
+        then(() => {
+          // Done();
+          console.log("Cancel request Done 2");
+        }).
+        catch((err) => {
+          console.log("Cancel request error 2: ", err);
+        });
+    }, 2000);
+
+    setup().
       then(deviceWallet.devGetFeatures).
       then((features1) => {
         expect(features1.pinProtection).to.be.false();
@@ -62,6 +71,7 @@ describe("Cancel Request test", function() {
       }).
       catch((err) => {
         console.log("ERROR: ", err);
+        done();
       });
   });
 });

--- a/test/cancel-request-test.js
+++ b/test/cancel-request-test.js
@@ -9,7 +9,7 @@ describe("Cancel Request test", function() {
   if (deviceWallet.getDevice() === null) {
     console.log("Skycoin hardware NOT FOUND, using emulator");
     deviceWallet.setDeviceType(deviceWallet.DeviceTypeEnum.EMULATOR);
-    //deviceWallet.setAutoPressButton(true, "R", false);
+    // DeviceWallet.setAutoPressButton(true, "R", false);
   } else {
     console.log("Skycoin hardware is plugged in");
     deviceWallet.setDeviceType(deviceWallet.DeviceTypeEnum.USB);


### PR DESCRIPTION
Changes:
- Before this improvement, all the pending requests where canceled correctly but the promise corresponding to that pending requests neither resolve or reject, but with this, now they correctly handle the Failure message returned by the cancel request.

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
yes

Comments about testing , should you have some
Is already tested and all the tests passed without any errors.