### PR TITLE
[device-wallet] fixes #114 - Button ACK in SkycoinSign message

### DIFF
--- a/device-wallet.js
+++ b/device-wallet.js
@@ -918,6 +918,9 @@ const devSkycoinSignMessage = function(addressN, message, pinCodeReader, passphr
       case messages.MessageType.MessageType_PinMatrixRequest:
         devSendPinCodeRequest(skycoinSignHander, pinCodeReader);
         break;
+      case messages.MessageType.MessageType_ButtonRequest:
+        devButtonRequestCallback(kind, dataBuffer, skycoinSignHander);
+        break;
       default:
         reject(new Error(`Unexpected answer from the device: ${kind}`));
         break;

--- a/device-wallet.js
+++ b/device-wallet.js
@@ -47,9 +47,9 @@ const setAutoPressButton = function(value, def, circular) {
     autoPressSequence = [].concat(sequence);
     autoPressId = 0;
 
+  } else {
+    throw new Error('Not in emulator');
   }
-
-  throw new Error('Not in emulator');
 
 };
 


### PR DESCRIPTION

Fixes #114 

Changes:
-  Handle case messages.MessageType.MessageType_ButtonRequest in devSkycoinSignMessage

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
yes

not needed new tests 

Related issues:

PR skycoin/hardware-wallet#213 for issue skycoin/hardware-wallet#77
