### PR TITLE
Send the deviceHandle.close callback instead of the function result ref #110

### DIFF
--- a/device-wallet.js
+++ b/device-wallet.js
@@ -1076,7 +1076,7 @@ const wordAckLoop = function(kind, wordReader, callback) {
           wordAckCallback(knd, dta);
         });
         deviceHandle.write(dataBytes);
-      }, deviceHandle.close());
+      }, deviceHandle.close);
       return;
     }
     deviceHandle.close();


### PR DESCRIPTION
Fixes #110 

Changes:
- Send the deviceHandle.close callback instead of the function result

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
no

Related issues:
this bug is related to this delta https://github.com/skycoin/hardware-wallet-js/commit/596f5989d8a753a0cbd8482201fd955e91203cbc