### PR TITLE
Add submodule instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 [![Build Status](https://travis-ci.com/skycoin/hardware-wallet-js.svg?branch=master)](https://travis-ci.com/skycoin/hardware-wallet-js)
 
+## Build instructions:
+
+Immediately after cloning this repository make sure submoudules are up-to-date by executing the following command.
+
+```
+git submodule update --init --recursive
+```
+
 Generate messages.js library:
 
     npm run make-protobuf-files


### PR DESCRIPTION
Changes:
- Add submodule init instructions to readme

Does this change need to mentioned in CHANGELOG.md?
no

Requires changes in protobuff specs?
no

Requires testing
no